### PR TITLE
support for mocking functions in test ymls

### DIFF
--- a/benchllm/data_types.py
+++ b/benchllm/data_types.py
@@ -70,7 +70,6 @@ class Evaluation(BaseModel):
     prediction: Prediction
     passed: bool
     eval_time_elapsed: float
-    call_errors: list[CallError] = []
 
 
 T = TypeVar("T")

--- a/benchllm/data_types.py
+++ b/benchllm/data_types.py
@@ -49,7 +49,7 @@ class Prediction(BaseModel):
     output: str
     time_elapsed: float
     function_id: FunctionID
-    calls: dict[str, list[dict[str, Any]]]
+    calls: dict[str, list[dict[str, Any]]] = {}
 
 
 class CallErrorType(str, Enum):

--- a/benchllm/data_types.py
+++ b/benchllm/data_types.py
@@ -1,8 +1,16 @@
+from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Generic, Optional, TypeVar
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
+
+
+class TestCall(BaseModel):
+    __test__ = False
+    name: str
+    arguments: dict[str, Any]
+    returns: Any
 
 
 class Test(BaseModel):
@@ -11,6 +19,7 @@ class Test(BaseModel):
     input: Any
     expected: list[str]
     file_path: Optional[Path] = None
+    calls: Optional[list[TestCall]] = None
 
 
 class FunctionID(BaseModel):
@@ -40,12 +49,28 @@ class Prediction(BaseModel):
     output: str
     time_elapsed: float
     function_id: FunctionID
+    calls: dict[str, list[dict[str, Any]]]
+
+
+class CallErrorType(str, Enum):
+    MISSING_FUNCTION = "Missing function"
+    MISSING_ARGUMENT = "Missing argument"
+    VALUE_MISMATCH = "Value mismatch"
+
+
+class CallError(BaseModel):
+    function_name: str
+    argument_name: Optional[str] = None
+    expected_value: Optional[Any] = None
+    actual_value: Optional[Any] = None
+    error_type: CallErrorType
 
 
 class Evaluation(BaseModel):
     prediction: Prediction
     passed: bool
     eval_time_elapsed: float
+    call_errors: list[CallError] = []
 
 
 T = TypeVar("T")

--- a/benchllm/evaluator/evaluator.py
+++ b/benchllm/evaluator/evaluator.py
@@ -60,6 +60,7 @@ class Evaluator(ABC):
         start = timer()
         match = self.evaluate_prediction(prediction)
         end = timer()
+
         evaluation = Evaluation(
             prediction=prediction, passed=isinstance(match, Evaluator.Match), eval_time_elapsed=end - start
         )

--- a/benchllm/similarity.py
+++ b/benchllm/similarity.py
@@ -17,7 +17,7 @@ def chat_completion_func(prompt: str, *, model: str) -> str:
 
 def complete_text(prompt: str, *, model: str) -> str:
     full_prompt = f"""
-    You will get two anwsers to a question, you should determine if they are semantically similar or not.
+    You will get two anwsers to a question, you should determine if they have the same meaning. Would two people agree that they mean the same, it's okay if different words are used.
     You can only answer "same" or "different", nothing else.
 
     input: {{ 

--- a/benchllm/similarity.py
+++ b/benchllm/similarity.py
@@ -17,7 +17,7 @@ def chat_completion_func(prompt: str, *, model: str) -> str:
 
 def complete_text(prompt: str, *, model: str) -> str:
     full_prompt = f"""
-    You will get two anwsers to a question, you should determine if they have the same meaning. Would two people agree that they mean the same, it's okay if different words are used.
+    You will get two anwsers to a question, you should determine if they are semantically similar or not.
     You can only answer "same" or "different", nothing else.
 
     input: {{ 

--- a/examples/weather_functions/default.yml
+++ b/examples/weather_functions/default.yml
@@ -1,0 +1,4 @@
+expected:
+  - "Yes"
+id: d80b8d57-9c50-44fe-b492-c3cab549d9f3
+input: Will it rain tomorrow?

--- a/examples/weather_functions/eval.py
+++ b/examples/weather_functions/eval.py
@@ -1,0 +1,8 @@
+from forecast import run
+
+import benchllm
+
+
+@benchllm.test()
+def eval(input: str):
+    return run(input)

--- a/examples/weather_functions/forecast.py
+++ b/examples/weather_functions/forecast.py
@@ -1,0 +1,58 @@
+import json
+
+import openai
+
+
+def get_n_day_weather_forecast(location: str, num_days: int):
+    return f"The weather in {location} will be rainy for the next {num_days} days."
+
+
+def chain(prompt: list[dict], functions):
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo-0613", messages=prompt, temperature=0.0, functions=functions
+    )
+
+    choice = response["choices"][0]
+    if choice.get("finish_reason") == "function_call":
+        function_call = choice["message"]["function_call"]
+        function_name = function_call["name"]
+        function_args = json.loads(function_call["arguments"])
+        fn = globals()[function_name]
+        output = fn(**function_args)
+        prompt.append({"role": "function", "name": function_name, "content": output})
+        return chain(prompt, functions)
+    else:
+        return response.choices[0].message.content.strip()
+
+
+def run(question: str):
+    messages = [
+        {
+            "role": "user",
+            "content": "Only answer questions with 'yes', 'no' or 'unknown', you must not reply with anything else",
+        },
+        {"role": "system", "content": "Use the get_n_day_weather_forecast function for weather questions"},
+        {"role": "user", "content": question},
+    ]
+
+    functions = [
+        {
+            "name": "get_n_day_weather_forecast",
+            "description": "Get an N-day weather forecast",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "The city and state, e.g. San Francisco, CA",
+                    },
+                    "num_days": {
+                        "type": "integer",
+                        "description": "The number of days to forecast. E.g. 1 for today, 2 for tomorrow etc",
+                    },
+                },
+                "required": ["location", "format", "num_days"],
+            },
+        },
+    ]
+    return chain(messages, functions)

--- a/examples/weather_functions/rainy.yml
+++ b/examples/weather_functions/rainy.yml
@@ -1,0 +1,10 @@
+expected:
+  - "yes"
+id: 4b717b39-da96-4ca3-8aaf-070c7f11449c
+input: I'm going to San Francisco today, do I need an umbrella?
+calls:
+  - name: forecast.get_n_day_weather_forecast
+    returns: It's rainy in San Francisco today.
+    arguments:
+      location: San Francisco
+      num_days: 1

--- a/examples/weather_functions/sunny.yml
+++ b/examples/weather_functions/sunny.yml
@@ -1,0 +1,10 @@
+expected:
+  - "no"
+id: 4b717b39-da96-4ca3-8aaf-070c7f11449c
+input: I live in London, can I expect rain today?
+calls:
+  - name: forecast.get_n_day_weather_forecast
+    returns: It's sunny today in London today.
+    arguments:
+      location: London
+      num_days: 1

--- a/examples/weather_functions/tomorrow.yml
+++ b/examples/weather_functions/tomorrow.yml
@@ -1,0 +1,9 @@
+expected:
+  - "yes"
+id: 4b717b39-da96-4ca3-8aaf-070c7f11449c
+input: Do I need a sun hat tomorrow?
+calls:
+  - name: forecast.get_n_day_weather_forecast
+    returns: It's sunny in your location tomorrow.
+    arguments:
+      num_days: 2


### PR DESCRIPTION
Introduces support for mocking functions and set expected values. 
This is useful when writing agents or chains calling out to python functions, for example getting the weather or running a sql query. 

```yml
expected:
  - "no"
id: 4b717b39-da96-4ca3-8aaf-070c7f11449c
input: I live in London, can I expect rain today?
calls:
  - name: forecast.get_n_day_weather_forecast
    returns: It's sunny today in London today.
    arguments:
      location: London
      num_days: 1
```

Every function described in `calls` will be mocked during the _testing_ phase of benchllm. 
Then during the _evaluation_ phase we will print out any unexpected calls, these are just treated as warnings and not errors at this point and values are matched with `=` and not via semantic/fuzzy matching (left as future work ;) )

<img width="917" alt="image" src="https://github.com/v7labs/benchllm/assets/102537/d6bf5222-9c85-4d25-bbdd-13bf5a84a4d1">
