### PR TITLE
Evaluators now return candidates with a score, adding embedding distance

### DIFF
--- a/benchllm/__init__.py
+++ b/benchllm/__init__.py
@@ -3,7 +3,12 @@ from pathlib import Path
 from typing import Callable, Type, TypeVar
 
 from .data_types import Evaluation, Prediction, Test  # noqa
-from .evaluator import Evaluator, SemanticEvaluator, StringMatchEvaluator  # noqa
+from .evaluator import (  # noqa
+    EmbeddingEvaluator,
+    Evaluator,
+    SemanticEvaluator,
+    StringMatchEvaluator,
+)
 from .input_types import ChatInput, SimilarityInput  # noqa
 from .similarity import semantically_similar  # noqa
 from .singleton import TestSingleton  # noqa
@@ -20,6 +25,7 @@ __all__ = [
     "StringMatchEvaluator",
     "SemanticEvaluator",
     "Evaluator",
+    "EmbeddingEvaluator",
 ]
 
 

--- a/benchllm/cache.py
+++ b/benchllm/cache.py
@@ -2,10 +2,17 @@ import json
 from pathlib import Path
 from typing import Optional
 
+from pydantic import BaseModel
+
 from benchllm.data_types import Evaluation, Prediction
 from benchllm.evaluator import Evaluator
 from benchllm.input_types import Json
 from benchllm.listener import EvaluatorListener
+
+
+class MemoryValue(BaseModel):
+    passed: bool
+    score: float
 
 
 class MemoryCache(Evaluator):
@@ -22,42 +29,45 @@ class MemoryCache(Evaluator):
         key1, key2 = json.dumps([answer1, answer2]), json.dumps([answer2, answer1])
         return key1 if key1 < key2 else key2
 
-    def lookup(self, answer1: Json, answer2: Json) -> Optional[bool]:
-        return self._data.get(self._key(answer1, answer2), None)
+    def lookup(self, answer1: Json, answer2: Json) -> Optional[MemoryValue]:
+        result = self._data.get(self._key(answer1, answer2), None)
+        if result:
+            return MemoryValue(**result)
+        return None
 
-    def store(self, answer1: Json, answer2: Json, value: bool) -> None:
+    def store(self, answer1: Json, answer2: Json, value: MemoryValue) -> None:
         key = self._key(answer1, answer2)
-        self._data[key] = value
+        self._data[key] = value.dict()
 
-    def evaluate_prediction(self, prediction: Prediction) -> Optional[Evaluator.Match]:
+    def evaluate_prediction(self, prediction: Prediction) -> list[Evaluator.Candidate]:
         uncached_expectations = []
+        candidates = []
         for expected in prediction.test.expected:
             lookup = self.lookup(expected, prediction.output)
             if lookup is None:
                 uncached_expectations.append(expected)
-            elif lookup:
-                # If we find a positive match we can stop comparing and just return.
-                # For negative matches we still need to check the other expected answers.
-                self._num_cache_hits += 1
-                return Evaluator.Match(prediction=prediction.output, expected=expected)
+            else:
+                candidates.append(Evaluator.Candidate(prediction=prediction.output, expected=expected, **lookup.dict()))
+
+        # If any of the cached candidates passed, we return them.
+        if any([candidate.passed for candidate in candidates]):
+            self._num_cache_hits += 1
+            return candidates
 
         # If all expectations were found in the cache but were negative matches,
         # we increment the cache hits counter and return None as there's no match.
         if not uncached_expectations:
             self._num_cache_hits += 1
-            return None
+            return candidates
 
         self._num_cache_misses += 1
         # set prediction.test.expected to only the ones that were not cached
         prediction = Prediction(**prediction.dict())
         prediction.test.expected = uncached_expectations
-        result = self._evaluator.evaluate_prediction(prediction)
-        if result:
-            self.store(result.expected, result.prediction, True)
-        else:
-            for expected in prediction.test.expected:
-                self.store(expected, prediction.output, False)
-        return result
+        candidates = self._evaluator.evaluate_prediction(prediction)
+        for candidate in candidates:
+            self.store(candidate.expected, candidate.prediction, MemoryValue(**candidate.dict()))
+        return candidates
 
     @property
     def num_cache_hits(self) -> int:

--- a/benchllm/cli/evaluator/interactive.py
+++ b/benchllm/cli/evaluator/interactive.py
@@ -8,7 +8,7 @@ from benchllm.evaluator import Evaluator
 
 
 class InteractiveEvaluator(Evaluator):
-    def evaluate_prediction(self, prediction: Prediction) -> Optional[Evaluator.Match]:
+    def evaluate_prediction(self, prediction: Prediction) -> list[Evaluator.Candidate]:
         header = (
             f'{typer.style("Does ", bold=True)}'
             f"{typer.style(prediction.output, fg=typer.colors.BRIGHT_BLUE, bold=True)}"
@@ -27,5 +27,15 @@ class InteractiveEvaluator(Evaluator):
         click_choice = click.Choice(options)
         response = typer.prompt(prompt_string, default="n", type=click_choice, show_choices=False).lower()
         if response == "n":
-            return None
-        return Evaluator.Match(prediction=prediction.output, expected=prediction.test.expected[int(response) - 1])
+            return [
+                Evaluator.Candidate(prediction=prediction.output, expected=expected, score=0.0, passed=False)
+                for expected in prediction.test.expected
+            ]
+        return [
+            Evaluator.Candidate(
+                prediction=prediction.output,
+                expected=prediction.test.expected[int(response) - 1],
+                score=1.0,
+                passed=True,
+            )
+        ]

--- a/benchllm/cli/evaluator/web.py
+++ b/benchllm/cli/evaluator/web.py
@@ -25,7 +25,7 @@ class WebEvaluator(Evaluator):
 
         put_markdown("# BenchLLM Web Evaluator")
 
-    def evaluate_prediction(self, prediction: Prediction) -> Optional[Evaluator.Match]:
+    def evaluate_prediction(self, prediction: Prediction) -> list[Evaluator.Candidate]:
         test_name = prediction.test.file_path or prediction.test.id
 
         put_markdown(f"## {test_name}")
@@ -42,6 +42,13 @@ class WebEvaluator(Evaluator):
         answer = radio("Pick the matching answer", options=options, required=True)
 
         if answer and isinstance(answer, int):
-            return Evaluator.Match(prediction=prediction.output, expected=prediction.test.expected[answer])
+            return [
+                Evaluator.Candidate(
+                    prediction=prediction.output, expected=prediction.test.expected[answer], score=1.0, passed=True
+                )
+            ]
         else:
-            return None
+            return [
+                Evaluator.Candidate(prediction=prediction.output, expected=expected, score=0.0, passed=False)
+                for expected in prediction.test.expected
+            ]

--- a/benchllm/cli/listener.py
+++ b/benchllm/cli/listener.py
@@ -156,7 +156,9 @@ class RichCliListener(TesterListener, EvaluatorListener):
             for failure in failed:
                 prediction = failure.prediction
                 relative_path = prediction.function_id.relative_str(self.root_dir)
-                print_centered(f" [red]{relative_path}[/red] :: [red]{prediction.test.file_path}[/red] ", "-")
+                print_centered(
+                    f" [red]{relative_path}[/red] :: [red]{prediction.test.file_path} ({failure.score:.2f})[/red] ", "-"
+                )
 
                 console = Console()
 

--- a/benchllm/cli/utils.py
+++ b/benchllm/cli/utils.py
@@ -3,7 +3,12 @@ from pathlib import Path
 
 from benchllm.cache import FileCache, MemoryCache
 from benchllm.cli.evaluator import InteractiveEvaluator, WebEvaluator
-from benchllm.evaluator import Evaluator, SemanticEvaluator, StringMatchEvaluator
+from benchllm.evaluator import (
+    EmbeddingEvaluator,
+    Evaluator,
+    SemanticEvaluator,
+    StringMatchEvaluator,
+)
 
 
 def output_dir_factory() -> Path:
@@ -27,6 +32,8 @@ def get_evaluator(evaluator_name: str, model: str, workers: int) -> Evaluator:
         return StringMatchEvaluator(workers=workers)
     elif evaluator_name == "web":
         return WebEvaluator()
+    elif evaluator_name == "embedding":
+        return EmbeddingEvaluator()
     else:
         raise ValueError(f"Unknown evaluator {evaluator_name}")
 

--- a/benchllm/data_types.py
+++ b/benchllm/data_types.py
@@ -75,6 +75,7 @@ class Evaluation(BaseModel):
     prediction: Prediction
     passed: bool
     eval_time_elapsed: float
+    score: float
 
 
 T = TypeVar("T")

--- a/benchllm/evaluator/__init__.py
+++ b/benchllm/evaluator/__init__.py
@@ -1,10 +1,5 @@
 from benchllm.evaluator.evaluator import Evaluator  # noqa
-
-
-def __force_import_order():
-    pass
-
-
+# Adding an empty comment to force import order to avoid circular imports
 from benchllm.evaluator.embedding import EmbeddingEvaluator  # noqa
 from benchllm.evaluator.semantic import SemanticEvaluator  # noqa
 from benchllm.evaluator.string_match import StringMatchEvaluator  # noqa

--- a/benchllm/evaluator/__init__.py
+++ b/benchllm/evaluator/__init__.py
@@ -1,3 +1,10 @@
 from benchllm.evaluator.evaluator import Evaluator  # noqa
+
+
+def __force_import_order():
+    pass
+
+
+from benchllm.evaluator.embedding import EmbeddingEvaluator  # noqa
 from benchllm.evaluator.semantic import SemanticEvaluator  # noqa
 from benchllm.evaluator.string_match import StringMatchEvaluator  # noqa

--- a/benchllm/evaluator/embedding.py
+++ b/benchllm/evaluator/embedding.py
@@ -1,0 +1,38 @@
+import numpy as np
+import openai
+
+from benchllm.data_types import Prediction
+from benchllm.evaluator import Evaluator
+
+
+class EmbeddingEvaluator(Evaluator):
+    def __init__(self, *, engine: str = "text-similarity-davinci-001", threshold: float = 0.9, workers: int = 1):
+        super().__init__(workers=workers)
+        self._engine = engine
+        self._threshold = threshold
+
+    def evaluate_prediction(self, prediction: Prediction) -> list[Evaluator.Candidate]:
+        output_embedding = get_embedding(prediction.output, engine=self._engine)
+        candidates = []
+        for expected in prediction.test.expected:
+            expected_embedding = get_embedding(expected, engine=self._engine)
+            similarity = cosine_similarity(output_embedding, expected_embedding)
+            candidates.append(
+                Evaluator.Candidate(
+                    prediction=prediction.output,
+                    expected=expected,
+                    score=similarity,
+                    passed=similarity > self._threshold,
+                )
+            )
+        return candidates
+
+
+# these also exist in openai.embeddings_utils but have additional dependencies
+def get_embedding(text: str, engine: str, **kwargs) -> list[float]:
+    text = text.replace("\n", " ")
+    return openai.Embedding.create(input=[text], engine=engine, **kwargs)["data"][0]["embedding"]
+
+
+def cosine_similarity(a, b):
+    return np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))

--- a/benchllm/evaluator/semantic.py
+++ b/benchllm/evaluator/semantic.py
@@ -6,12 +6,22 @@ from benchllm.similarity import semantically_similar
 
 
 class SemanticEvaluator(Evaluator):
-    def __init__(self, *, model: str = "gpt-3", workers: int = 1):
+    def __init__(self, *, model: str = "gpt-3", workers: int = 1, early_quitting: bool = True):
         super().__init__(workers=workers)
         self.model = model
+        self.early_quitting = early_quitting
 
-    def evaluate_prediction(self, prediction: Prediction) -> Optional[Evaluator.Match]:
+    def evaluate_prediction(self, prediction: Prediction) -> list[Evaluator.Candidate]:
+        candidates = []
         for expected in prediction.test.expected:
             if semantically_similar(expected, prediction.output, model=self.model):
-                return Evaluator.Match(prediction=prediction.output, expected=expected)
-        return None
+                candidate = Evaluator.Candidate(prediction=prediction.output, expected=expected, score=1.0, passed=True)
+                if self.early_quitting:
+                    return [candidate]
+                else:
+                    candidates.append(candidate)
+            else:
+                candidates.append(
+                    Evaluator.Candidate(prediction=prediction.output, expected=expected, score=0.0, passed=False)
+                )
+        return candidates

--- a/benchllm/evaluator/string_match.py
+++ b/benchllm/evaluator/string_match.py
@@ -1,6 +1,3 @@
-import json
-from typing import Optional
-
 from benchllm.data_types import Prediction
 from benchllm.evaluator import Evaluator
 
@@ -22,9 +19,12 @@ class StringMatchEvaluator(Evaluator):
 
         return expected == output
 
-    def evaluate_prediction(self, prediction: Prediction) -> Optional[Evaluator.Match]:
+    def evaluate_prediction(self, prediction: Prediction) -> list[Evaluator.Candidate]:
         output = prediction.output
+        candidates = []
         for expected in prediction.test.expected:
             if self.match_strings(expected, output):
-                return Evaluator.Match(prediction=prediction.output, expected=expected)
-        return None
+                candidates.append(Evaluator.Candidate(prediction=output, expected=expected, score=1.0, passed=True))
+            else:
+                candidates.append(Evaluator.Candidate(prediction=output, expected=expected, score=0.0, passed=False))
+        return candidates

--- a/examples/vector_retrieval/1.yml
+++ b/examples/vector_retrieval/1.yml
@@ -1,5 +1,5 @@
 expected:
-  - true
+  - "yes"
 id: 78ce604e-dc76-4f21-9514-c48b17948773
 input:
   Is the Seychelles parakeet extinct? (respond only with "yes", "no" or "don't

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ include = "benchllm"
 
 [tool.isort]
 profile = "black"
-skip = ["benchllm/evaluator/__init__.py"]
 
 [tool.mypy]
 plugins = [ "pydantic.mypy",]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ include = "benchllm"
 
 [tool.isort]
 profile = "black"
+skip = ["benchllm/evaluator/__init__.py"]
 
 [tool.mypy]
 plugins = [ "pydantic.mypy",]

--- a/test/evaulator/test_evalutator.py
+++ b/test/evaulator/test_evalutator.py
@@ -11,8 +11,8 @@ from benchllm.evaluator import Evaluator
 
 
 class NoopEvaluator(Evaluator):
-    def evaluate_prediction(self, prediction: Prediction) -> Evaluator.Match:
-        return Evaluator.Match(prediction=prediction.output, expected=prediction.output)
+    def evaluate_prediction(self, prediction: Prediction) -> list[Evaluator.Candidate]:
+        return [Evaluator.Candidate(prediction=prediction.output, expected=prediction.output, score=1.0, passed=True)]
 
 
 def test_evaluator_can_load_prediction_file():


### PR DESCRIPTION
Evaluators now return `list[Candidate] instead of `optional[Match]`. 

```python
class Candidate(BaseModel):
        prediction: Json
        expected: Json
        score: float
        passed: bool
```

Note that Candidate is return both for good and bad matches, and now also includes a score so we can easily tell if the match was close or far from passing. 
There is no way to set the threshold yet, and only the embedding evaluator is using it (0.9). 

We also introduced a new Evaluator, `EmbeddingEvaluator`, it uses `text-similarity-davinci-001` and cosine distance to check if the output is close to the expected output. 

You can use it from the command line with `--evaluator embedding` 


